### PR TITLE
Use build profile to enable RTEMS cross build

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+epics-seq (2.2.3-5) unstable; urgency=medium
+
+  * Use build profile to enable RTEMS cross build
+
+ -- Martin Konrad <konrad@frib.msu.edu>  Thu, 13 Sep 2018 14:39:18 -0400
+
 epics-seq (2.2.3-4) unstable; urgency=medium
 
   * Fix Conflicts:

--- a/debian/control
+++ b/debian/control
@@ -2,11 +2,12 @@ Source: epics-seq
 Section: admin
 Priority: optional
 Maintainer: Martin Konrad <konrad@frib.msu.edu>
-Build-Depends: debhelper (>= 9), epics-debhelper (>= 8.14~), re2c (>= 0.9.9), epics-dev,
-               rtems-epics-mvme2100,
-               rtems-epics-mvme3100,
-               rtems-epics-mvme5500,
-               rtems-epics-pc386,
+Build-Depends: debhelper (>= 9.20141010), dpkg-dev (>= 1.17.14),
+               epics-debhelper (>= 8.14~), re2c (>= 0.9.9), epics-dev,
+               rtems-epics-mvme2100 <pkg.epics-base.rtems>,
+               rtems-epics-mvme3100 <pkg.epics-base.rtems>,
+               rtems-epics-mvme5500 <pkg.epics-base.rtems>,
+               rtems-epics-pc386 <pkg.epics-base.rtems>,
 XS-Rtems-Build-Depends: rtems-epics
 Standards-Version: 3.9.6
 Homepage: http://www-csr.bessy.de/control/SoftDist/sequencer/
@@ -43,6 +44,7 @@ Description: State Notation Language and Sequencer
  implementation, consisting of the SNL compiler and runtime system.
 
 Package: rtems-seq-mvme2100
+Build-Profiles: <pkg.epics-base.rtems>
 Architecture: all
 Depends: ${rtems:Depends},
          epics-seq-dev (>= ${source:Version}),
@@ -62,6 +64,7 @@ Description: State Notation Language and Sequencer
  This package contains support for the MVME2100 PowerPC based VME SBC.
 
 Package: rtems-seq-mvme3100
+Build-Profiles: <pkg.epics-base.rtems>
 Architecture: all
 Depends: ${rtems:Depends},
          epics-seq-dev (>= ${source:Version}),
@@ -81,6 +84,7 @@ Description: State Notation Language and Sequencer
  This package contains support for the MVME3100 PowerPC based VME SBC.
 
 Package: rtems-seq-mvme5500
+Build-Profiles: <pkg.epics-base.rtems>
 Architecture: all
 Depends: ${rtems:Depends},
          epics-seq-dev (>= ${source:Version}),
@@ -100,6 +104,7 @@ Description: State Notation Language and Sequencer
  This package contains support for the MVME5500 PowerPC based VME SBC.
 
 Package: rtems-seq-pc386
+Build-Profiles: <pkg.epics-base.rtems>
 Architecture: all
 Depends: ${rtems:Depends},
          epics-seq-dev (>= ${source:Version}),

--- a/debian/source/lintian-overrides
+++ b/debian/source/lintian-overrides
@@ -1,2 +1,10 @@
 # For epics-debhelper
 epics-seq source: unknown-field-in-dsc rtems-build-depends
+epics-seq source: invalid-restriction-formula-in-build-profiles-field <pkg.epics-base.rtems> rtems-seq-mvme2100
+epics-seq source: invalid-restriction-formula-in-build-profiles-field <pkg.epics-base.rtems> rtems-seq-mvme3100
+epics-seq source: invalid-restriction-formula-in-build-profiles-field <pkg.epics-base.rtems> rtems-seq-mvme5500
+epics-seq source: invalid-restriction-formula-in-build-profiles-field <pkg.epics-base.rtems> rtems-seq-pc386
+epics-seq source: invalid-profile-name-in-source-relation pkg.epics-base.rtems [build-depends: rtems-epics-mvme2100 <pkg.epics-base.rtems>]
+epics-seq source: invalid-profile-name-in-source-relation pkg.epics-base.rtems [build-depends: rtems-epics-mvme3100 <pkg.epics-base.rtems>]
+epics-seq source: invalid-profile-name-in-source-relation pkg.epics-base.rtems [build-depends: rtems-epics-mvme5500 <pkg.epics-base.rtems>]
+epics-seq source: invalid-profile-name-in-source-relation pkg.epics-base.rtems [build-depends: rtems-epics-pc386 <pkg.epics-base.rtems>]


### PR DESCRIPTION
This allows facilities that do not use RTEMS to get rid of the complexity of building this package's RTEMS dependencies. Set the environment variable `DEB_BUILD_PROFILES=pkg.epics-seq.rtems` when compiling to enable the RTEMS build.